### PR TITLE
Update to Noir 1.0

### DIFF
--- a/crates/chacha20/Nargo.toml
+++ b/crates/chacha20/Nargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chacha20"
 type = "lib"
-authors = ["Sleepingshell"]
-compiler_version = "0.10.5"
+authors = ["nuke-web3","Sleepingshell"]
+compiler_version = "1.0"
 
 [dependencies]

--- a/crates/chacha20/src/block.nr
+++ b/crates/chacha20/src/block.nr
@@ -1,10 +1,10 @@
-/// Runs a 64-byte block of chacha20. 
+/// Runs a 64-byte block of chacha20.
 /// A new working state is instantiated with the key, nonce and counter.
 /// Then run the `inner_block` function 10 times on the working state.
 /// After the 10 rounds, the working state is added to the original state
-/// 
+///
 /// Return: the serialized bytes of the working state (64 bytes)
-fn chacha20_block(key: [u32; 8], nonce: [u32; 3], counter: u32) -> [u32; 16] {
+pub fn chacha20_block(key: [u32; 8], nonce: [u32; 3], counter: u32) -> [u32; 16] {
     let mut state = ChaChaState::new(key, nonce, counter);
     let mut working_state = ChaChaState::new(key, nonce, counter);
 
@@ -18,7 +18,7 @@ fn chacha20_block(key: [u32; 8], nonce: [u32; 3], counter: u32) -> [u32; 16] {
 
 /// Structure that holds the chacha20 state
 struct ChaChaState {
-    state: [u32; 16]
+    state: [u32; 16],
 }
 
 impl ChaChaState {
@@ -27,13 +27,9 @@ impl ChaChaState {
         Self {
             state: [
                 0x61707865, 0x3320646e, 0x79622d32, 0x6b206574, // Constants
-                key[0], key[1],
-                key[2], key[3],
-                key[4], key[5],
-                key[6], key[7],
-                counter, nonce[0],
-                nonce[1], nonce[2]
-            ]
+                key[0], key[1], key[2], key[3], key[4], key[5], key[6], key[7], counter, nonce[0],
+                nonce[1], nonce[2],
+            ],
         }
     }
 
@@ -54,14 +50,14 @@ impl ChaChaState {
         }
     }
 
-    /// Serializes the 16 4-byte word working state to 64 bytes (`u8`) 
+    /// Serializes the 16 4-byte word working state to 64 bytes (`u8`)
     fn to_le_bytes(self) -> [u8; 64] {
         let mut res = [0; 64];
         for i in 0..16 {
-            res[i*4] = (self.state[i] & 0xFF) as u8;
-            res[i*4 + 1] = ((self.state[i] & 0xFF00) >> 8) as u8;
-            res[i*4 + 2] = ((self.state[i] & 0xFF0000) >> 16) as u8;
-            res[i*4 + 3] = ((self.state[i] & 0xFF000000) >> 24) as u8;
+            res[i * 4] = (self.state[i] & 0xFF) as u8;
+            res[i * 4 + 1] = ((self.state[i] & 0xFF00) >> 8) as u8;
+            res[i * 4 + 2] = ((self.state[i] & 0xFF0000) >> 16) as u8;
+            res[i * 4 + 3] = ((self.state[i] & 0xFF000000) >> 24) as u8;
         }
 
         res
@@ -132,21 +128,35 @@ impl ChaChaState {
         self.state[13] = state_13;
         self.state[14] = state_14;
         self.state[15] = state_15;
-    
     }
 }
 
 /// Performs a quarter round of chacha20 on 4 32-byte values.
 fn quarter_round(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32) {
-    *a += *b; *d ^= *a; left_rotation(d, 16);
-    *c += *d; *b ^= *c; left_rotation(b, 12);
-    *a += *b; *d ^= *a; left_rotation(d, 8);
-    *c += *d; *b ^= *c; left_rotation(b, 7);
+    *a += *b;
+    *d ^= *a;
+    left_rotation(d, 16);
+    *c += *d;
+    *b ^= *c;
+    left_rotation(b, 12);
+    *a += *b;
+    *d ^= *a;
+    left_rotation(d, 8);
+    *c += *d;
+    *b ^= *c;
+    left_rotation(b, 7);
 }
 
-/// Performs bitwise rotation. NOT safe for n > 32
-fn left_rotation(x: &mut u32, n: u32) {
-    *x = ( (*x << n) + (*x >> (32-n)) );
+/// Performs bitwise rotation.
+///
+/// ### SAFETY
+///
+/// You *must* guarantee that `n <= 32` at runtime!
+/// `32 - n` could underflow!
+/// 
+/// Consider using `assert(n < 32);`
+fn left_rotation(x: &mut u32, n: u8) {
+    *x = ((*x << n ) + (*x >> (32 - n) ));
 }
 
 // The test data of this function is from section 2.2.1 of RFC7539
@@ -170,7 +180,7 @@ fn test_quarter_round() {
 fn test_block_function() {
     let mut key = [0 as u32; 8];
     for i in 0..8 {
-        key[i] = (4*i | (4*i + 1) << 8 | (4*i + 2) << 16 | (4*i + 3) << 24);
+        key[i] = (4 * i | (4 * i + 1) << 8 | (4 * i + 2) << 16 | (4 * i + 3) << 24);
     }
 
     let mut nonce = [0; 3];
@@ -182,10 +192,9 @@ fn test_block_function() {
     let result = chacha20_block(key, nonce, counter);
 
     let expected_result = [
-        0x10f1e7e4, 0xd13b5915, 0x500fdd1f, 0xa32071c4,
-        0xc7d1f4c7, 0x33c06803, 0x0422aa9a, 0xc3d46c4e,
-        0xd2826446, 0x079faa09, 0x14c2d705, 0xd98b02a2,
-        0xb5129cd1, 0xde164eb9, 0xcbd083e8, 0xa2503c4e
+        0x10f1e7e4, 0xd13b5915, 0x500fdd1f, 0xa32071c4, 0xc7d1f4c7, 0x33c06803, 0x0422aa9a,
+        0xc3d46c4e, 0xd2826446, 0x079faa09, 0x14c2d705, 0xd98b02a2, 0xb5129cd1, 0xde164eb9,
+        0xcbd083e8, 0xa2503c4e,
     ];
 
     for i in 0..16 {

--- a/crates/chacha20/src/block.nr
+++ b/crates/chacha20/src/block.nr
@@ -46,7 +46,7 @@ impl ChaChaState {
     /// Add two ChaChaState's together elementwise
     fn add(&mut self, other: Self) {
         for i in 0..16 {
-            self.state[i] += other.state[i];
+            self.state[i] = std::wrapping_add(self.state[i], other.state[i]);
         }
     }
 
@@ -67,12 +67,24 @@ impl ChaChaState {
     fn to_le_4bytes(self) -> [u32; 16] {
         let mut res = [0; 16];
         for i in 0..16 {
-            res[i] = ((self.state[i] & 0xFF) << 24)
-                + ((self.state[i] & 0xFF00) << 8)
-                + ((self.state[i] & 0xFF0000) >> 8)
-                + ((self.state[i] & 0xFF000000) >> 24);
-        }
+            let val = self.state[i];
 
+            let byte0 = val & 0xFF;
+            let byte1 = (val >> 8) & 0xFF;
+            let byte2 = (val >> 16) & 0xFF;
+            let byte3 = (val >> 24) & 0xFF;
+
+            let part1 = byte0 << 24;
+            let part2 = byte1 << 16;
+            let part3 = byte2 << 8;
+            let part4 = byte3;
+
+            let sum1 = std::wrapping_add(part1, part2);
+            let sum2 = std::wrapping_add(sum1, part3);
+            let sum3 = std::wrapping_add(sum2, part4);
+
+            res[i] = sum3;
+        }
         res
     }
 
@@ -150,17 +162,16 @@ fn quarter_round(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32) {
     left_rotation(b, 7);
 }
 
-
 /// Performs bitwise rotation.
 ///
 /// ### SAFETY
 ///
 /// You *must* guarantee that `n <= 32` at runtime!
 /// `32 - n` could underflow!
-/// 
+///
 /// Consider using `assert(n < 32);`
 fn left_rotation(x: &mut u32, n: u8) {
-    *x = ((*x << n ) + (*x >> (32 - n) ));
+    *x = ((*x << n) + (*x >> (32 - n)));
 }
 
 // The test data of this function is from section 2.2.1 of RFC7539

--- a/crates/chacha20/src/block.nr
+++ b/crates/chacha20/src/block.nr
@@ -133,19 +133,23 @@ impl ChaChaState {
 
 /// Performs a quarter round of chacha20 on 4 32-byte values.
 fn quarter_round(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32) {
-    *a += *b;
+    *a = std::wrapping_add(*a, *b);
     *d ^= *a;
     left_rotation(d, 16);
-    *c += *d;
+
+    *c = std::wrapping_add(*c, *d);
     *b ^= *c;
     left_rotation(b, 12);
-    *a += *b;
+
+    *a = std::wrapping_add(*a, *b);
     *d ^= *a;
     left_rotation(d, 8);
-    *c += *d;
+
+    *c = std::wrapping_add(*c, *d);
     *b ^= *c;
     left_rotation(b, 7);
 }
+
 
 /// Performs bitwise rotation.
 ///

--- a/crates/chacha20/src/lib.nr
+++ b/crates/chacha20/src/lib.nr
@@ -10,17 +10,19 @@ pub fn ChaCha20<let N: u32>(
     plaintext: [u32; N],
 ) -> [u32; N] {
     let mut res = [0; N];
-    for j in 0..N {
+    for j in 0..N / 16 {
         let key_stream = block::chacha20_block(key, nonce, counter + j);
         for t in 0..16 {
             res[16 * j + t] = plaintext[16 * j + t] ^ key_stream[t];
         }
     }
 
-    let j = N;
-    let key_stream = block::chacha20_block(key, nonce, counter + j);
-    for t in 0..N {
-        res[16 * j + t] = plaintext[16 * j + t] ^ key_stream[t];
+    if (N % 16 != 0) {
+        let j = N / 16;
+        let key_stream = block::chacha20_block(key, nonce, counter + j);
+        for t in 0..N % 16 {
+            res[16 * j + t] = plaintext[16 * j + t] ^ key_stream[t];
+        }
     }
 
     res

--- a/crates/chacha20/src/lib.nr
+++ b/crates/chacha20/src/lib.nr
@@ -3,21 +3,24 @@ mod block;
 /// Encrypts an arbitrary sized message by running chacha20.
 /// The stream cipher of ChaCha20 is composed of running the block_function with an increasing counter,
 /// which provides 64-bytes of keystream at a time.
-fn ChaCha20<N>(key: [u32; 8], nonce: [u32; 3], counter: u32, plaintext: [u32; N]) -> [u32; N] {
+pub fn ChaCha20<let N: u32>(
+    key: [u32; 8],
+    nonce: [u32; 3],
+    counter: u32,
+    plaintext: [u32; N],
+) -> [u32; N] {
     let mut res = [0; N];
-    for j in 0..(N as u32/16) {
-        let key_stream = block::chacha20_block(key, nonce, counter+j as u32);
+    for j in 0..N {
+        let key_stream = block::chacha20_block(key, nonce, counter + j);
         for t in 0..16 {
-            res[16*j + t] = plaintext[16*j + t] ^ key_stream[t];
+            res[16 * j + t] = plaintext[16 * j + t] ^ key_stream[t];
         }
     }
 
-    if (N as u32 % 16 != 0) {
-        let j = (N as u32 / 16) as Field;
-        let key_stream = block::chacha20_block(key, nonce, counter+j as u32);
-        for t in 0..((N as u32 % 16) as Field) {
-            res[16*j + t] = plaintext[16 * j + t] ^ key_stream[t];
-        }
+    let j = N;
+    let key_stream = block::chacha20_block(key, nonce, counter + j);
+    for t in 0..N {
+        res[16 * j + t] = plaintext[16 * j + t] ^ key_stream[t];
     }
 
     res
@@ -27,9 +30,9 @@ fn ChaCha20<N>(key: [u32; 8], nonce: [u32; 3], counter: u32, plaintext: [u32; N]
 /// since, for now, the function operations on 4-byte words
 #[test]
 fn test_ChaCha20() {
-    let mut key = [0 as u32; 8];
+    let mut key = [0; 8];
     for i in 0..8 {
-        key[i] = (4*i | (4*i + 1) << 8 | (4*i + 2) << 16 | (4*i + 3) << 24);
+        key[i] = (4 * i | (4 * i + 1) << 8 | (4 * i + 2) << 16 | (4 * i + 3) << 24);
     }
 
     let mut nonce = [0; 3];
@@ -38,27 +41,21 @@ fn test_ChaCha20() {
     let counter = 1;
 
     let plaintext = [
-        0x4c616469, 0x65732061, 0x6e642047, 0x656e746c,
-        0x656d656e, 0x206f6620, 0x74686520, 0x636c6173,
-        0x73206f66, 0x20273939, 0x3a204966, 0x20492063,
-        0x6f756c64, 0x206f6666, 0x65722079, 0x6f75206f,
-        0x6e6c7920, 0x6f6e6520, 0x74697020, 0x666f7220,
-        0x74686520, 0x66757475, 0x72652c20, 0x73756e73,
-        0x63726565, 0x6e20776f, 0x756c6420, 0x62652069,
-        0x742e0000
+        0x4c616469, 0x65732061, 0x6e642047, 0x656e746c, 0x656d656e, 0x206f6620, 0x74686520,
+        0x636c6173, 0x73206f66, 0x20273939, 0x3a204966, 0x20492063, 0x6f756c64, 0x206f6666,
+        0x65722079, 0x6f75206f, 0x6e6c7920, 0x6f6e6520, 0x74697020, 0x666f7220, 0x74686520,
+        0x66757475, 0x72652c20, 0x73756e73, 0x63726565, 0x6e20776f, 0x756c6420, 0x62652069,
+        0x742e0000,
     ];
 
     let ciphertext = ChaCha20(key, nonce, counter, plaintext);
 
     let expected_ciphertext = [
-        0x6e2e359a, 0x2568f980, 0x41ba0728, 0xdd0d6981,
-        0xe97e7aec, 0x1d4360c2, 0x0a27afcc, 0xfd9fae0b,
-        0xf91b65c5, 0x524733ab, 0x8f593dab, 0xcd62b357,
-        0x1639d624, 0xe65152ab, 0x8f530c35, 0x9f0861d8,
-        0x07ca0dbf, 0x500d6a61, 0x56a38e08, 0x8a22b65e,
-        0x52bc514d, 0x16ccf806, 0x818ce91a, 0xb7793736,
-        0x5af90bbf, 0x74a35be6, 0xb40b8eed, 0xf2785e42,
-        0x874d7403
+        0x6e2e359a, 0x2568f980, 0x41ba0728, 0xdd0d6981, 0xe97e7aec, 0x1d4360c2, 0x0a27afcc,
+        0xfd9fae0b, 0xf91b65c5, 0x524733ab, 0x8f593dab, 0xcd62b357, 0x1639d624, 0xe65152ab,
+        0x8f530c35, 0x9f0861d8, 0x07ca0dbf, 0x500d6a61, 0x56a38e08, 0x8a22b65e, 0x52bc514d,
+        0x16ccf806, 0x818ce91a, 0xb7793736, 0x5af90bbf, 0x74a35be6, 0xb40b8eed, 0xf2785e42,
+        0x874d7403,
     ];
 
     let decrypted_plaintext = ChaCha20(key, nonce, counter, ciphertext);

--- a/crates/chacha20_example/Nargo.toml
+++ b/crates/chacha20_example/Nargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "chacha20_example"
 type = "bin"
-authors = ["Sleepingshell"]
-compiler_version = "0.10.5"
+authors = ["nuke-web3","Sleepingshell"]
+compiler_version = "1.0"
 
 [dependencies]
 chacha20 = { path = "../chacha20" }

--- a/crates/chacha20_example/src/main.nr
+++ b/crates/chacha20_example/src/main.nr
@@ -1,5 +1,5 @@
 use dep::chacha20::ChaCha20;
 
-fn main(key: [u32; 8], nonce: [u32; 3], counter: u32, plaintext: [u32; 16]) -> pub [u32; 16]  {
-    ChaCha20(key, nonce, counter, plaintext)    
+fn main(key: [u32; 8], nonce: [u32; 3], counter: u32, plaintext: [u32; 16]) -> pub [u32; 16] {
+    ChaCha20(key, nonce, counter, plaintext)
 }


### PR DESCRIPTION
Notably changes to use `u32` as `N` for size of plaintext array, using loops with `u32` rather than `Field`.

This also caused the need to do explicit overflow constraints due to adds and bit-shifts potentially overflowing, causing errors like:

```
Testing test_ChaCha20 ... error: Integer 6159851055, sized 33, is over the max supported size of 32 for the blackbox function's inputs
```